### PR TITLE
ci: migrate firebase project

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "omlette-blog"
+    "default": "project-omlette"
   }
 }

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn && yarn ci && yarn build
+      - run: yarn unprepare && yarn && yarn build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # production
 /build
+.firebase
 
 # misc
 .DS_Store

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,7 @@
 {
   "hosting": {
+    "site": "omlettes-blog",
+    "public": "public",
     "source": ".",
     "ignore": [
       "firebase.json",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "lint": "next lint",
     "tsc": "tsc --noemit",
     "test": "jest",
-    "ci": "yarn tsc && yarn lint && yarn test && npm pkg delete scripts.prepare",
-    "prepare": "husky install"
+    "ci": "yarn tsc && yarn lint && yarn test",
+    "prepare": "husky install",
+    "unprepare": "npm pkg delete scripts.prepare"
   },
   "dependencies": {
     "@ouellettec/design-system": "^1.0.0-alpha.4",


### PR DESCRIPTION
Due to the limitations to how many projects one billing account can have the blog is being moved under a new project called "Project Omlette".